### PR TITLE
Fix remaining validation errors

### DIFF
--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -53,14 +53,14 @@
 22	,	,	PUNCT	Punct	_	15	punct	_	SpaceAfter=No
 23	'	'	PUNCT	Punct	_	3	punct	_	_
 24	arsa	arsa	VERB	PastInd	Mood=Ind|Tense=Past	0	root	_	_
-25	Peadar	Peadar	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	SpaceAfter=No
+25	Peadar	Peadar	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	24	nsubj	_	SpaceAfter=No
 26	.	.	PUNCT	.	_	24	punct	_	_
 
 # sent_id = 457
 # text = Bean shuidhte dhéanta...
 1	Bean	bean	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-2	shuidhte	suidhte	ADJ	Adj	Form=Len|VerbForm=Part	1	amod	_	_
-3	dhéanta	déanta	ADJ	Adj	Degree=Pos|Form=Len	1	amod	_	SpaceAfter=No
+2	shuidhte	suite	ADJ	Adj	Case=Nom|Form=Len|Gender=Fem|Number=Sing	1	amod	_	_
+3	dhéanta	déanta	ADJ	Adj	Case=Nom|Form=Len|Gender=Fem|Number=Sing	1	amod	_	SpaceAfter=No
 4	...	...	PUNCT	...	_	1	punct	_	_
 
 # sent_id = 458
@@ -127,15 +127,15 @@
 # text = Ba é Bryan McFadden ón bPopghrúpa 'Westlife' agus Kerry Katona, cailín a bhíodh mar amhranaí sa ghrúpa 'Atomic Kitten', a bhí ag pósadh.
 1	Ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	3	cop	_	_
 2	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nmod	_	_
-3	Bryan	Bryan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
+3	Bryan	Bryan	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	0	root	_	NamedEntity=Yes
 4	McFadden	McFadden	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	flat:name	_	NamedEntity=Yes
 5	ón	ó	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
 6	bPopghrúpa	popghrúpa	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	nmod	_	_
 7	'	'	PUNCT	Punct	_	8	punct	_	SpaceAfter=No
-8	Westlife	Westlife	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
+8	Westlife	Westlife	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
 9	'	'	PUNCT	Punct	_	8	punct	_	_
 10	agus	agus	CCONJ	Coord	_	11	cc	_	_
-11	Kerry	Kerry	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
+11	Kerry	Kerry	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	3	conj	_	NamedEntity=Yes
 12	Katona	Katona	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
 14	cailín	cailín	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	11	appos	_	_
@@ -146,8 +146,8 @@
 19	sa	i	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
 20	ghrúpa	grúpa	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	nmod	_	_
 21	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
-22	Atomic	Atomic	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat	_	_
-23	Kitten	Kitten	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	flat:foreign	_	SpaceAfter=No
+22	Atomic	Atomic	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	20	appos	_	_
+23	Kitten	Kitten	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	22	flat	_	SpaceAfter=No
 24	'	'	PUNCT	Punct	_	22	punct	_	SpaceAfter=No
 25	,	,	PUNCT	Punct	_	26	punct	_	_
 26	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	27	mark:prt	_	_
@@ -166,7 +166,7 @@
 6	'	'	PUNCT	Punct	_	2	punct	_	_
 7	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	8	mark:prt	_	_
 8	deir	abair	VERB	VTI	Mood=Ind|Tense=Pres	0	root	_	_
-9	Tom	Tom	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	SpaceAfter=No
+9	Tom	Tom	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	SpaceAfter=No
 10	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 463
@@ -322,7 +322,7 @@
 8	sa	i	ADP	Art	Number=Sing|PronType=Art	10	case	_	_
 9	dá	dó	NUM	Num	NumType=Card	10	nummod	_	_
 10	chogadh	cogadh	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	obl	_	_
-11	dhomhanda	domhanda	ADJ	Adj	Case=Nom|Form=Len|Gender=Masc|Number=Plur	10	amod	_	_
+11	dhomhanda	domhanda	ADJ	Adj	Case=Nom|Form=Len|Gender=Masc|NounType=NotSlender|Number=Plur	10	amod	_	_
 12	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	14	nsubj	_	_
 13	d'	do	PART	Vb	PartType=Vb	14	mark:prt	_	SpaceAfter=No
 14	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	10	acl:relcl	_	_
@@ -341,7 +341,7 @@
 27	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
 28	áir	ár	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	_
 29	san	i	ADP	Art	Number=Sing|PronType=Art	30	case	_	_
-30	Eoraip	Eoraip	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	22	obl	_	_
+30	Eoraip	Eoraip	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	22	obl	_	_
 31	agus	agus	CCONJ	Coord	_	32	cc	_	_
 32	níos	níos	PART	Cmp	PartType=Comp	33	mark:prt	_	_
 33	mó	mór	ADJ	Adj	Degree=Cmp,Sup	34	amod	_	_
@@ -428,7 +428,7 @@
 4	1955	1955	NUM	Num	_	3	nmod	_	_
 5	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	7	cop	_	_
 6	ea	ea	PRON	Pers	Number=Sing|Person=3	7	nmod	_	_
-7	Moloney	Moloney	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
+7	Moloney	Moloney	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 475
@@ -515,7 +515,7 @@
 # text = Dar le Hawkins ní raibh údarás ach aige féin amháin agus a oifig a leithéidí d'armais sochraide a cheadú.
 1	Dar	dar	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	le	le	ADP	Simp	_	3	case	_	_
-3	Hawkins	Hawkins	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
+3	Hawkins	Hawkins	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
 4	ní	ní	PART	Vb	PartType=Vb|Polarity=Neg	5	advmod	_	_
 5	raibh	bí	VERB	PastInd	Mood=Ind|Polarity=Neg|Tense=Past	1	ccomp	_	_
 6	údarás	údarás	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
@@ -542,7 +542,7 @@
 3	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
 4	háite	áit	NOUN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Fearghas	Fearghas	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	appos	_	NamedEntity=Yes
+6	Fearghas	Fearghas	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	2	appos	_	NamedEntity=Yes
 7	Ó	ó	PART	Pat	PartType=Pat	6	flat:name	_	NamedEntity=Yes
 8	hÍr	Ír	PROPN	Noun	Definite=Def|Form=HPref|Gender=Masc|Number=Sing	6	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 9	,	,	PUNCT	Punct	_	10	punct	_	_
@@ -755,9 +755,9 @@
 1	Amharc	amharc	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
 2	géar	géar	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	1	amod	_	_
 3	ag	ag	ADP	Simp	_	4	case	_	_
-4	Dara	Dara	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
+4	Dara	Dara	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 5	Ó	ó	PART	Pat	PartType=Pat	4	flat:name	_	NamedEntity=Yes
-6	Cinnéide	Cinnéide	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
+6	Cinnéide	Cinnéide	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	4	flat:name	_	NamedEntity=Yes
 7	ó	ó	ADP	Simp	_	8	case	_	_
 8	Chiarraí	Ciarraí	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	4	nmod	_	NamedEntity=Yes
 9	Thiar	thiar	ADV	Dir	_	8	amod	_	NamedEntity=Yes
@@ -1406,7 +1406,7 @@
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 6	beirt	beirt	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
 7	Aire	aire	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	6	nmod	_	NamedEntity=Yes
-8	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
+8	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	NamedEntity=Yes
 9	againn	ag	ADP	Prep	Number=Plur|Person=1	5	obl:prep	_	_
 10	anseo	anseo	ADV	Loc	_	5	advmod	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
@@ -1715,8 +1715,8 @@
 11	'	'	PUNCT	Punct	_	10	punct	_	_
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	Irish	Irish	X	_	Foreign=Yes	1	xcomp:pred	_	_
-15	Independent	Independent	X	_	Foreign=Yes	14	flat:foreign	_	_
+14	Irish	Irish	PROPN	_	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	1	xcomp:pred	_	_
+15	Independent	Independent	PROPN	_	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	14	flat	_	_
 16	sna	i	ADP	Art	Number=Plur|PronType=Art	17	case	_	_
 17	blianta	bliain	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	1	obl:tmod	_	_
 18	1927	1927	NUM	Num	_	17	nmod	_	_
@@ -1886,7 +1886,7 @@
 11	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	3	csubj:cleft	_	_
 12	i	i	ADP	Simp	_	13	case	_	_
 13	mBéal	Béal	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
-14	Feirste	Feirste	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
+14	Feirste	Feirste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	17	cc	_	_
 16	b'	is	AUX	Cop	Form=VF|Tense=Past|VerbForm=Cop	17	cop	_	SpaceAfter=No
 17	fhada	fada	ADJ	Adj	Degree=Pos|Form=Len	3	conj	_	_
@@ -2352,8 +2352,8 @@
 3	réir	réir	NOUN	Cmpd	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PrepForm=Cmpd	2	fixed	_	_
 4	phobalbhreith	pobalbhreith	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	14	obl	_	_
 5	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	6	det	_	_
-6	Galway	Galway	PROPN	Noun	Foreign=Yes	4	nmod	_	_
-7	Advertiser	Advertiser	PROPN	Noun	Foreign=Yes	6	flat:foreign	_	SpaceAfter=No
+6	Galway	Galway	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	4	nmod	_	_
+7	Advertiser	Advertiser	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	6	flat	_	SpaceAfter=No
 8	,	,	PUNCT	Punct	_	10	punct	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
 10	tseachtain	seachtain	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
@@ -2447,7 +2447,7 @@
 24	faoi	faoi	ADP	Cmpd	PrepForm=Cmpd	27	case	_	_
 25	bhráid	bráid	NOUN	Cmpd	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing|PrepForm=Cmpd	24	fixed	_	_
 26	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
-27	Ombudsman	Ombudsman	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	obl	_	_
+27	Ombudsman	ombudsman	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	obl	_	_
 28	nuair	nuair	SCONJ	Subord	_	30	mark	_	_
 29	is	is	AUX	Cop	Tense=Pres|VerbForm=Cop	30	cop	_	_
 30	gá	gá	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	13	advcl	_	_
@@ -2491,7 +2491,7 @@
 2	na	an	DET	Art	Definite=Def|Number=Plur|PronType=Art	3	det	_	_
 3	páistí	páiste	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Plur	1	nsubj	_	_
 4	ruaig	ruaig	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	1	obj	_	_
-5	amháin	amháin	ADJ	Adj	Degree=Pos	3	amod	_	_
+5	amháin	amháin	ADJ	Adj	Case=Nom|Gender=Fem|Number=Sing	3	amod	_	_
 6	ar	ar	ADP	Simp	_	8	case	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	siopa	siopa	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
@@ -2875,7 +2875,7 @@
 27	ar	ar	ADP	Simp	_	28	case	_	_
 28	bhunús	bunús	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	25	obl	_	_
 29	agus	agus	CCONJ	Coord	_	30	cc	_	_
-30	todhchaí	todhchaí	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	28	conj	_	_
+30	todhchaí	todhchaí	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	28	conj	_	_
 31	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	32	det	_	_
 32	tionscnaimh	tionscnamh	NOUN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	28	nmod	_	SpaceAfter=No
 33	,	,	PUNCT	Punct	_	35	punct	_	_
@@ -3231,11 +3231,11 @@
 2	dheireadh	deireadh	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	1	fixed	_	SpaceAfter=No
 3	,	,	PUNCT	Punct	_	1	punct	_	_
 4	don	do	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	Sun	Sun	PROPN	Noun	Foreign=Yes|Number=Sing	12	nmod	_	_
-6	Alliance	Alliance	PROPN	Noun	Foreign=Yes|Number=Sing	5	flat:foreign	_	_
-7	Chase	Chase	PROPN	Noun	Foreign=Yes|Number=Sing	5	flat:foreign	_	_
+5	Sun	Sun	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	12	nmod	_	_
+6	Alliance	Alliance	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	5	flat	_	_
+7	Chase	Chase	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	5	flat	_	_
 8	ag	ag	ADP	Simp	_	9	case	_	_
-9	Cheltenham	Cheltenham	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
+9	Cheltenham	Cheltenham	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	5	punct	_	_
 11	ag	ag	ADP	Simp	_	12	case	_	_
 12	seo	seo	PRON	Dem	PronType=Dem	0	root	_	_
@@ -3255,9 +3255,9 @@
 26	7/1	7/1	NUM	Num	_	23	nmod	_	SpaceAfter=No
 27	)	)	PUNCT	Punct	_	21	punct	_	SpaceAfter=No
 28	;	;	PUNCT	Punct	_	29	punct	_	_
-29	Hill	Hill	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	17	conj	_	NamedEntity=Yes
-30	of	of	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	29	flat:name	_	NamedEntity=Yes
-31	Tullow	Tullow	PROPN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	29	flat:name	_	NamedEntity=Yes
+29	Hill	Hill	NOUN	Noun	Foreign=Yes|Number=Sing	17	conj	_	NamedEntity=Yes
+30	of	of	NOUN	Noun	Foreign=Yes|Number=Sing	29	flat:name	_	NamedEntity=Yes
+31	Tullow	Tullow	PROPN	Noun	Definite=Def|Foreign=Yes|Number=Sing	29	flat:name	_	NamedEntity=Yes
 32	(	(	PUNCT	Punct	_	34	punct	_	SpaceAfter=No
 33	3	3	NUM	Num	_	34	nummod	_	_
 34	phointe	pointe	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	29	nmod	_	SpaceAfter=No
@@ -4302,8 +4302,8 @@
 9	ainm	ainm	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	7	acl:relcl	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	12	punct	_	_
 11	'	'	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
-12	Education	Education	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	7	appos	_	_
-13	First	First	NOUN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	12	flat:foreign	_	SpaceAfter=No
+12	Education	Education	NOUN	Noun	Case=Nom|Foreign=Yes|Number=Sing	7	appos	_	_
+13	First	First	NOUN	Noun	Case=Nom|Foreign=Yes|Number=Sing	12	flat	_	SpaceAfter=No
 14	'	'	PUNCT	Punct	_	12	punct	_	SpaceAfter=No
 15	,	,	PUNCT	Punct	_	12	punct	_	_
 16	sna	i	ADP	Art	Number=Plur|PronType=Art	17	case	_	_
@@ -4716,9 +4716,9 @@
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	dochar	dochar	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	obl	_	_
-15	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	16	nsubj	_	_
+15	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	16	obj	_	_
 16	dhéanann	déan	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	14	acl:relcl	_	_
-17	cailleadh	cailleadh	NOUN	Noun	VerbForm=Inf	16	obj	_	_
+17	cailleadh	cailleadh	NOUN	Noun	VerbForm=Inf	16	nsubj	_	_
 18	acmhainní	acmhainn	NOUN	Noun	Case=Gen|Gender=Fem|NounType=Strong|Number=Plur	17	nmod	_	_
 19	den	de	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
 20	chineál	cineál	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	17	nmod	_	_
@@ -5454,10 +5454,10 @@
 # text = Níor rith Storm Alert ag Ascot an tseachain seo caite.
 1	Níor	níor	PART	Vb	PartType=Vb|Polarity=Neg|Tense=Past	2	advmod	_	_
 2	rith	rith	VERB	VTI	Mood=Ind|Polarity=Neg|Tense=Past	0	root	_	_
-3	Storm	Storm	PROPN	Noun	Foreign=Yes|Number=Sing	2	nsubj	_	NamedEntity=Yes
-4	Alert	Alert	PROPN	Noun	Foreign=Yes|Number=Sing	3	flat:foreign	_	NamedEntity=Yes
+3	Storm	Storm	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	2	nsubj	_	NamedEntity=Yes
+4	Alert	Alert	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	3	flat	_	NamedEntity=Yes
 5	ag	ag	ADP	Simp	_	6	case	_	_
-6	Ascot	Ascot	PROPN	Noun	Definite=Def|Number=Sing	2	obl	_	_
+6	Ascot	Ascot	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	2	obl	_	_
 7	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	8	det	_	_
 8	tseachain	seachtain	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|Typo=Yes	2	obl:tmod	_	_
 9	seo	seo	DET	Det	PronType=Dem	8	det	_	_
@@ -5737,9 +5737,9 @@
 13	i	i	ADP	Simp	_	14	case	_	_
 14	gcumann	cumann	NOUN	Noun	Case=Nom|Form=Ecl|Gender=Masc|Number=Sing	11	obl	_	_
 15	The	the	X	Foreign	Foreign=Yes	14	nmod	_	_
-16	Week	Week	X	Foreign	Foreign=Yes	14	flat:foreign	_	_
-17	in	in	X	Foreign	Foreign=Yes	14	flat:foreign	_	_
-18	Politics	Politics	X	Foreign	Foreign=Yes	14	flat:foreign	_	_
+16	Week	Week	X	Foreign	Foreign=Yes	15	flat:foreign	_	_
+17	in	in	X	Foreign	Foreign=Yes	15	flat:foreign	_	_
+18	Politics	Politics	X	Foreign	Foreign=Yes	15	flat:foreign	_	_
 19	ar	ar	ADP	Simp	_	20	case	_	_
 20	fáil	fáil	NOUN	Noun	VerbForm=Inf	11	xcomp	_	_
 21	acu	ag	ADP	Prep	Number=Plur|Person=3	20	obl:prep	_	_
@@ -5750,7 +5750,7 @@
 26	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	25	nsubj	_	_
 27	ag	ag	ADP	Simp	_	28	case	_	_
 28	Brian	Brian	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	25	obl	_	NamedEntity=Yes
-29	Hayes	Hayes	PROPN	Noun	Definite=Def	28	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+29	Hayes	Hayes	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	28	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 30	?	?	PUNCT	?	_	6	punct	_	_
 
 # sent_id = 685
@@ -5851,7 +5851,7 @@
 2	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	3	mark:prt	_	_
 3	dúradh	abair	VERB	VTI	Mood=Ind|Person=0|Tense=Past	9	advcl	_	_
 4	sa	i	ADP	Art	Number=Sing|PronType=Art	5	case	_	_
-5	Champion	Champion	PROPN	Noun	Foreign=Yes	3	obl	_	_
+5	Champion	Champion	PROPN	Noun	Definite=Def|Foreign=Yes	3	obl	_	_
 6	1915	1915	NUM	Num	_	5	nmod	_	SpaceAfter=No
 7	:	:	PUNCT	Punct	_	3	punct	_	_
 8	Níor	is	AUX	Cop	Polarity=Neg|Tense=Past|VerbForm=Cop	9	cop	_	_
@@ -5968,7 +5968,7 @@
 39	Aontachtaíocha	aontachtaíoch	ADJ	Adj	Case=Nom|Gender=Masc|NounType=NotSlender|Number=Plur	38	amod	_	_
 40	i	i	ADP	Simp	_	41	case	_	_
 41	mBéal	Béal	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	31	nmod	_	NamedEntity=Yes
-42	Feirste	Feirste	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	41	nmod	_	NamedEntity=Yes|SpaceAfter=No
+42	Feirste	Feirste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	41	nmod	_	NamedEntity=Yes|SpaceAfter=No
 43	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 691
@@ -6306,7 +6306,7 @@
 26	Oinigh	oineach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
 27	Saoil	saol	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	25	nmod	_	_
 28	den	de	ADP	Art	Number=Sing|PronType=Art	29	case	_	_
-29	COI	COI	PROPN	Abr	Abbr=Yes	25	nmod	_	_
+29	COI	COI	PROPN	Abr	Abbr=Yes|Definite=Def	25	nmod	_	_
 30	agus	agus	CCONJ	Coord	_	32	cc	_	_
 31	de	de	ADP	Simp	_	32	case	_	_
 32	COÉ	COÉ	PROPN	Abr	Abbr=Yes|Definite=Def	29	conj	_	SpaceAfter=No
@@ -6832,7 +6832,7 @@
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
 9	ghuthán	guthán	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	conj	_	_
 10	le	le	ADP	Simp	_	11	case	_	_
-11	hamazon	amazon	X	Foreign	Foreign=Yes|Form=HPref	9	nmod	_	_
+11	hamazon	amazon	PROPN	Foreign	Case=Nom|Definite=Def|Foreign=Yes|Form=HPref|Number=Sing	9	nmod	_	_
 12	agus	agus	CCONJ	Coord	_	13	cc	_	_
 13	post	post	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	3	conj	_	_
 14	ar	ar	ADP	Simp	_	13	nmod	_	_
@@ -7005,7 +7005,7 @@
 20	Seán	Seán	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	appos	_	NamedEntity=Yes
 21	Noone	Noone	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:name	_	NamedEntity=Yes
 22	ón	ó	ADP	Art	Number=Sing|PronType=Art	23	case	_	_
-23	SELC	SELC	PROPN	Abr	Abbr=Yes	20	nmod	_	SpaceAfter=No
+23	SELC	SELC	PROPN	Abr	Abbr=Yes|Definite=Def	20	nmod	_	SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
 25	atá	bí	VERB	PresInd	Form=Direct|Mood=Ind|PronType=Rel|Tense=Pres	20	acl:relcl	_	_
 26	luaite	luaite	ADJ	Adj	VerbForm=Part	25	xcomp:pred	_	_
@@ -7212,10 +7212,10 @@
 8	na	an	DET	Art	Case=Gen|Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	bhfíricí	fíric	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Fem|NounType=Strong|Number=Plur	5	nmod	_	_
 10	faoi	faoi	ADP	Simp	_	11	case	_	_
-11	pholasaí	polasaí	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
+11	pholasaí	polasaí	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	_
 12	nua	nua	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	11	amod	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
-14	INTO	INTO	PROPN	Abr	Abbr=Yes	11	nmod	_	_
+14	INTO	INTO	PROPN	Abr	Abbr=Yes|Definite=Def	11	nmod	_	_
 15	in	in	ADP	Cmpd	PrepForm=Cmpd	18	case	_	_
 16	aghaidh	aghaidh	NOUN	Cmpd	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PrepForm=Cmpd	15	fixed	_	_
 17	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
@@ -7310,8 +7310,8 @@
 9	ag	ag	ADP	Simp	_	10	case	_	_
 10	obair	obair	NOUN	Noun	VerbForm=Vnoun	2	xcomp	_	_
 11	le	le	ADP	Simp	_	12	case	_	_
-12	Fair	Fair	X	_	Foreign=Yes	10	obl	_	NamedEntity=Yes
-13	City	City	X	_	Foreign=Yes	12	flat:foreign	_	NamedEntity=Yes
+12	Fair	Fair	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	10	obl	_	NamedEntity=Yes
+13	City	City	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	12	flat	_	NamedEntity=Yes
 14	anuraidh	anuraidh	ADV	Temp	_	2	advmod	_	_
 15	agus	agus	SCONJ	Subord	_	16	mark	_	_
 16	aithne	aithne	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	2	advcl	_	_
@@ -7359,7 +7359,7 @@
 3	rinne	déan	VERB	VTI	Mood=Ind|Tense=Past	33	advcl	_	_
 4	Tomás	Tomás	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	NamedEntity=Yes
 5	de	de	PART	Pat	PartType=Pat	4	flat:name	_	NamedEntity=Yes
-6	Bhaldraithe	Baldraithe	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+6	Bhaldraithe	Bhaldraithe	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
 8	nach	nach	PART	Vb	Form=Direct|PartType=Vb|Polarity=Neg|PronType=Rel	9	mark:prt	_	_
 9	maireann	mair	VERB	VTI	Mood=Ind|Polarity=Neg|Tense=Pres	4	acl:relcl	_	SpaceAfter=No
@@ -7368,7 +7368,7 @@
 12	ar	ar	ADP	Simp	_	14	case	_	_
 13	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	14	det	_	_
 14	leabhar	leabhar	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	obl	_	_
-15	The	the	X	Foreign	Foreign=Yes	14	nmod	_	_
+15	The	the	X	Foreign	Foreign=Yes	14	appos	_	_
 16	Irish	Irish	X	Foreign	Foreign=Yes	15	flat:foreign	_	_
 17	of	of	X	Foreign	Foreign=Yes	15	flat:foreign	_	_
 18	Erris	Erris	X	Foreign	Foreign=Yes	15	flat:foreign	_	SpaceAfter=No
@@ -7379,8 +7379,8 @@
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	21	flat:name	_	NamedEntity=Yes
 24	Fheisligh	Feisleach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	21	flat:name	_	NamedEntity=Yes
 25	in	i	ADP	Simp	_	26	case	_	_
-26	Studica	Studica	X	Foreign	Foreign=Yes	14	nmod	_	NamedEntity=Yes
-27	Celtica	Celtica	X	Foreign	Foreign=Yes	26	flat:foreign	_	NamedEntity=Yes
+26	Studica	Studica	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	14	nmod	_	NamedEntity=Yes
+27	Celtica	Celtica	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	26	flat	_	NamedEntity=Yes
 28	V	V	NUM	Num	NumType=Card	26	nmod	_	_
 29	(	(	PUNCT	Punct	_	31	punct	_	SpaceAfter=No
 30	in	i	ADP	Simp	_	31	case	_	_
@@ -7462,7 +7462,7 @@
 16	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	15	nmod	_	NamedEntity=Yes
 17	4	4	NUM	Num	_	14	nmod	_	SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	a	a	PART	Vb	PartType=Vb	20	mark:prt	_	_
+19	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	20	mark:prt	_	_
 20	bheidh	bí	VERB	VI	Form=Len|Mood=Ind|Tense=Fut	3	csubj:cleft	_	_
 21	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	22	det	_	_
 22	spórt	spórt	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	20	nsubj	_	_
@@ -7816,9 +7816,9 @@
 17	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	_
 18	dá	de	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	19	case	_	_
 19	mhórshaothar	mórshaothar	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	_
-20	Dancing	Dancing	X	_	Foreign=Yes	19	nmod	_	_
-21	at	at	X	_	Foreign=Yes	20	flat:foreign	_	_
-22	Lughnasa	Lughnasa	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	20	flat:foreign	_	_
+20	Dancing	Dancing	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	19	appos	_	_
+21	at	at	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	20	flat	_	_
+22	Lughnasa	Lughnasa	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	20	flat	_	_
 23	a	a	PART	Inf	PartType=Inf	24	mark	_	_
 24	chur	cur	NOUN	Noun	Form=Len|VerbForm=Inf	8	xcomp	_	_
 25	ar	ar	ADP	Simp	_	27	case	_	_
@@ -8266,7 +8266,7 @@
 38	go	go	PART	Vb	PartType=Cmpl	39	mark:prt	_	_
 39	dtugtaí	tabhair	VERB	VTI	Aspect=Imp|Form=Ecl|Person=0|Tense=Past	36	ccomp	_	_
 40	Ára	ára	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	39	obj	_	NamedEntity=Yes
-41	Chaomháin	Caomhán	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	40	nmod	_	NamedEntity=Yes
+41	Chaomháin	Caomhán	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	nmod	_	NamedEntity=Yes
 42	ar	ar	ADP	Simp	_	44	case	_	_
 43	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	44	det	_	_
 44	oileán	oileán	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	39	obl	_	_
@@ -8465,8 +8465,8 @@
 14	easaontóirí	easaontóir	NOUN	Noun	Case=Nom|Gender=Masc|Number=Plur	12	obl	_	_
 15	i	i	ADP	Simp	_	16	case	_	_
 16	bpáirtí	páirtí	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	14	nmod	_	_
-17	David	David	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
-18	Trimble	Trimble	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+17	David	David	PROPN	Noun	Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
+18	Trimble	Trimble	PROPN	Noun	Definite=Def|Foreign=Yes|Gender=Masc|Number=Sing	17	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 19	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 794
@@ -8708,9 +8708,9 @@
 
 # sent_id = 806
 # text = Treasure Island Uncut ar Network 2 Dé Luain ag 10.30.
-1	Treasure	Treasure	X	Foreign	Foreign=Yes	0	root	_	_
-2	Island	Island	X	Foreign	Foreign=Yes	1	flat:foreign	_	_
-3	Uncut	Uncut	X	Foreign	Foreign=Yes	1	flat:foreign	_	_
+1	Treasure	Treasure	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	0	root	_	_
+2	Island	Island	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	1	flat	_	_
+3	Uncut	Uncut	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	1	flat	_	_
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	Network	Network	X	Foreign	Foreign=Yes	1	nmod	_	NamedEntity=Yes
 6	2	2	NUM	Num	_	5	flat	_	NamedEntity=Yes
@@ -9617,7 +9617,7 @@
 23	mbeadh	bí	VERB	Cond	Form=Ecl|Mood=Cnd	18	advcl	_	_
 24	beirt	beirt	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	23	nsubj	_	_
 25	Bhráthar	bráthair	NOUN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes
-26	Saidhclaps	Saidhclaps	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
+26	Saidhclaps	Saidhclaps	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	nmod	_	NamedEntity=Yes
 27	i	i	ADP	Simp	_	28	case	_	_
 28	bprobhinse	proibhinse	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing|Typo=Yes	23	obl	_	_
 29	Leatha	leath	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	28	nmod	_	NamedEntity=Yes
@@ -9654,8 +9654,8 @@
 17	d'	do	PART	Vb	PartType=Vb	18	mark:prt	_	SpaceAfter=No
 18	fhoilsigh	foilsigh	VERB	VT	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	Belfast	Belfast	PROPN	Noun	Foreign=Yes|Number=Sing	18	nsubj	_	NamedEntity=Yes
-21	Telegraph	Telegraph	PROPN	Noun	Foreign=Yes|Number=Sing	20	flat:foreign	_	NamedEntity=Yes
+20	Belfast	Belfast	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	18	nsubj	_	NamedEntity=Yes
+21	Telegraph	Telegraph	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	20	flat	_	NamedEntity=Yes
 22	cartún	cartún	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	18	obj	_	_
 23	le	le	ADP	Simp	_	24	case	_	_
 24	Rowel	Rowel	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	22	nmod	_	NamedEntity=Yes
@@ -10224,7 +10224,7 @@
 20	,	,	PUNCT	Punct	_	23	punct	_	_
 21	is	agus	CCONJ	Coord	_	23	cc	_	_
 22	ba	is	AUX	Cop	Tense=Past|VerbForm=Cop	23	cop	_	_
-23	mhór	mór	ADJ	Adj	Degree=Pos|Form=Len	18	conj	_	_
+23	mhór	mór	ADJ	Adj	Degree=Pos|Form=Len	2	conj	_	_
 24	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	_
 25	seó	seó	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	27	det	_	_
@@ -10252,9 +10252,9 @@
 7	náisiúnaigh	náisiúnach	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
 8	leis	le	ADP	Simp	_	10	case	_	_
 9	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	10	det	_	_
-10	Royal	Royal	PROPN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	1	obl	_	_
-11	Ulster	Ulster	PROPN	Noun	Foreign=Yes|Gender=Masc|Number=Sing	10	flat:foreign	_	_
-12	Constabulary	Constabulary	X	Unknown	Foreign=Yes	10	flat:foreign	_	SpaceAfter=No
+10	Royal	Royal	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	1	obl	_	_
+11	Ulster	Ulster	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	10	flat	_	_
+12	Constabulary	Constabulary	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	10	flat	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	16	punct	_	_
 14	agus	agus	CCONJ	Coord	_	16	cc	_	_
 15	ní	is	AUX	Cop	Polarity=Neg|Tense=Pres|VerbForm=Cop	16	cop	_	_
@@ -10365,7 +10365,7 @@
 12	a	a	PART	Vb	Form=Indirect|PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	ghnóthaigh	gnóthaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 14	gradam	gradam	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
-15	Grammy	Grammy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nmod	_	NamedEntity=Yes
+15	Grammy	Grammy	PROPN	Noun	Definite=Def|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	le	le	ADP	Simp	_	17	case	_	_
 17	déanaí	déanaí	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	13	obl:tmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
@@ -10863,7 +10863,7 @@
 25	,	,	PUNCT	Punct	_	26	punct	_	_
 26	Ardeaspag	ardeaspag	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
 27	Ard	Ard	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes
-28	Mhacha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
+28	Mhacha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	27	nmod	_	NamedEntity=Yes|SpaceAfter=No
 29	,	,	PUNCT	Punct	_	31	punct	_	_
 30	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	31	det	_	_
 31	Dr	dochtúir	NOUN	Abr	Abbr=Yes|Definite=Def	16	conj	_	NamedEntity=Yes
@@ -10919,8 +10919,8 @@
 4	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	5	nsubj	_	_
 5	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	acl:relcl	_	_
 6	i	i	ADP	Simp	_	7	case	_	_
-7	Riasg	Riasg	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
-8	Buidhe	Buidhe	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
+7	Riasg	Riasg	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	NamedEntity=Yes
+8	Buidhe	buí	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	NamedEntity=Yes
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	11	det	_	_
 11	chósta	cósta	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	5	obl	_	_
@@ -10928,7 +10928,7 @@
 13	ó	ó	ADP	Simp	_	14	case	_	_
 14	thuaidh	thuaidh	ADV	Dir	_	11	advmod	_	_
 15	de	de	ADP	Simp	_	16	case	_	_
-16	Sgalasaig	Sgalasaig	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
+16	Sgalasaig	Sgalasaig	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 17	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	18	obj	_	_
 18	tréigeadh	tréig	VERB	VTI	Mood=Ind|Person=0|Tense=Past	1	acl:relcl	_	_
 19	ag	ag	ADP	Simp	_	20	case	_	_
@@ -10942,7 +10942,7 @@
 # sent_id = 891
 # text = Chaith Alan a chloigeann san aer agus rinne gáire faoina ndúirt Learaí leis.
 1	Chaith	caith	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Alan	Alan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Alan	Alan	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	nmod:poss	_	_
 4	chloigeann	cloigeann	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	obj	_	_
 5	san	i	ADP	Art	Number=Sing|PronType=Art	6	case	_	_
@@ -10952,7 +10952,7 @@
 9	gáire	gáire	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	8	obj	_	_
 10	faoina	faoi	ADP	Rel	PronType=Rel	8	obl	_	_
 11	ndúirt	abair	VERB	VTI	Form=Ecl|Mood=Ind|Tense=Past	10	acl:relcl	_	_
-12	Learaí	Learaí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
+12	Learaí	Learaí	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	11	nsubj	_	_
 13	leis	le	ADP	Prep	Gender=Masc|Number=Sing|Person=3	11	obl:prep	_	SpaceAfter=No
 14	.	.	PUNCT	.	_	1	punct	_	_
 
@@ -11030,7 +11030,7 @@
 22	an	an	DET	Art	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	NamedEntity=Yes
 23	Ghaorthaigh	Gaorthach	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes|SpaceAfter=No
 24	,	,	PUNCT	Punct	_	25	punct	_	_
-25	Tammy	Tammy	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
+25	Tammy	Tammy	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	NamedEntity=Yes
 26	Ní	ní	PART	Pat	PartType=Pat	25	flat:name	_	NamedEntity=Yes
 27	Laoire	Laoire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	25	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
@@ -11038,20 +11038,20 @@
 30	nuachta	nuacht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	29	nmod	_	_
 31	TG4	TG4	PROPN	Abr	Abbr=Yes|Definite=Def	30	nmod	_	SpaceAfter=No
 32	,	,	PUNCT	Punct	_	33	punct	_	_
-33	Áine	Áine	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
+33	Áine	Áine	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
 34	Ní	ní	PART	Pat	PartType=Pat	33	flat:name	_	NamedEntity=Yes
 35	Shé	Sé	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	33	flat:name	_	NamedEntity=Yes
 36	as	as	ADP	Simp	_	37	case	_	_
-37	Dún	dún	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
+37	Dún	dún	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	33	nmod	_	NamedEntity=Yes
 38	Chaoin	Caoin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	37	nmod	_	NamedEntity=Yes|SpaceAfter=No
 39	,	,	PUNCT	Punct	_	41	punct	_	_
 40	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	41	det	_	_
 41	t-amhránaí	amhránaí	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	16	conj	_	_
-42	Áine	Áine	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	41	appos	_	NamedEntity=Yes
+42	Áine	Áine	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	41	appos	_	NamedEntity=Yes
 43	Uí	uí	PART	Pat	PartType=Pat	42	flat:name	_	NamedEntity=Yes
 44	Laoithe	Laoithe	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	42	flat:name	_	NamedEntity=Yes
 45	agus	agus	CCONJ	Coord	_	46	cc	_	_
-46	Máire	Máire	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
+46	Máire	Máire	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	16	conj	_	NamedEntity=Yes
 47	Ní	ní	PART	Pat	PartType=Pat	46	flat:name	_	NamedEntity=Yes
 48	Chéilleachair	Céilleachar	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	46	flat:name	_	NamedEntity=Yes
 49	as	as	ADP	Simp	_	50	case	_	_
@@ -11063,7 +11063,7 @@
 # sent_id = 896
 # text = Bhí Mick ina shuí romhainn fós nuair a chuamar isteach agus d'insíomar an scéal dó.
 1	Bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
-2	Mick	Mick	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
+2	Mick	Mick	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	4	case	_	_
 4	shuí	suí	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	1	xcomp:pred	_	_
 5	romhainn	roimh	ADP	Prep	Number=Plur|Person=1	4	obl:prep	_	_
@@ -11096,12 +11096,12 @@
 12	mar	mar	SCONJ	Subord	_	14	mark	_	_
 13	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	14	mark:prt	_	_
 14	dúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	1	parataxis	_	_
-15	Beairtlín	Beairtlín	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
+15	Beairtlín	Beairtlín	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	buachaill	buachaill	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	15	conj	_	_
 18	aimsire	aimsir	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	17	compound	_	_
-19	Liam	Liam	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	17	appos	_	NamedEntity=Yes
-20	Bhid	Bid	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+19	Liam	Liam	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	17	appos	_	NamedEntity=Yes
+20	Bhid	Bid	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 21	,	,	PUNCT	Punct	_	22	punct	_	_
 22	fear	fear	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	17	appos	_	_
 23	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	24	det	_	_
@@ -11116,7 +11116,7 @@
 32	agus	agus	CCONJ	Coord	_	34	cc	_	_
 33	a	a	PART	Vb	Form=Indirect|PartType=Vb|PronType=Rel	34	mark:prt	_	_
 34	mbíodh	bí	VERB	PastImp	Aspect=Imp|Form=Ecl|Tense=Past	27	conj	_	_
-35	Nóra	Nóra	PROPN	Noun	Definite=Def|Gender=Fem|Number=Sing	34	nsubj	_	_
+35	Nóra	Nóra	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	34	nsubj	_	_
 36	ag	ag	ADP	Simp	_	37	case	_	_
 37	suirí	suirí	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	34	xcomp:pred	_	_
 38	go	go	PART	Ad	PartType=Ad	39	mark:prt	_	_
@@ -11175,7 +11175,7 @@
 # text = Ghlaoigh an Róisteach chomh maith, é ag comhairliú stuamachta - agus an oiread sin amhrais ar infheisteoirí móra faoin gcomhnascadh ón gcéad lá, ba é a bharúil féin go dtiocfadh ardú ar luach ar na scaranna a bhí ag Ruairí sa Bhainc de los a bhfaoisimh; ardú gearrthréimhseach ar a laghad.
 1	Ghlaoigh	glaoigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	3	det	_	_
-3	Róisteach	Róiste	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
+3	Róisteach	Róiste	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	nsubj	_	_
 4	chomh	chomh	ADV	Its	_	1	advmod	_	_
 5	maith	maith	ADJ	Adj	Degree=Pos	4	fixed	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
@@ -11214,7 +11214,7 @@
 39	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	40	nsubj	_	_
 40	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	38	acl:relcl	_	_
 41	ag	ag	ADP	Simp	_	42	case	_	_
-42	Ruairí	Ruairí	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	40	obj	_	_
+42	Ruairí	Ruairí	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	40	obj	_	_
 43	sa	i	ADP	Art	Number=Sing|PronType=Art	44	case	_	_
 44	Bhainc	banc	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	40	obl	_	_
 45	de	de	ADP	Simp	_	46	case	_	_
@@ -11232,7 +11232,7 @@
 # sent_id = 901
 # text = Rugadh Harold Alexander de shliocht plandóra i Londain sa bhliain 1891.
 1	Rugadh	beir	VERB	VTI	Mood=Ind|Person=0|Tense=Past	0	root	_	_
-2	Harold	Harold	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	1	obj	_	NamedEntity=Yes
+2	Harold	Harold	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	obj	_	NamedEntity=Yes
 3	Alexander	Alexander	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	2	flat:name	_	NamedEntity=Yes
 4	de	de	ADP	Simp	_	5	case	_	_
 5	shliocht	sliocht	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	1	obl	_	_
@@ -11328,7 +11328,7 @@
 6	fhág	fág	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	csubj:cleft	_	_
 7	baile	baile	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	6	obj	_	_
 8	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	9	det	_	_
-9	Luan	Luan	PROPN	Noun	Definite=Def|Gender=Masc|Number=Sing	6	obl:tmod	_	_
+9	Luan	Luan	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	6	obl:tmod	_	_
 10	sin	sin	DET	Det	PronType=Dem	9	det	_	_
 11	a	a	PART	Vb	Form=Indirect|PartType=Vb|PronType=Rel	12	mark:prt	_	_
 12	raibh	bí	VERB	PastInd	Mood=Ind|Tense=Past	2	acl:relcl	_	_

--- a/ga_idt-ud-dev.conllu
+++ b/ga_idt-ud-dev.conllu
@@ -10365,7 +10365,7 @@
 12	a	a	PART	Vb	Form=Indirect|PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	ghnóthaigh	gnóthaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	1	advcl	_	_
 14	gradam	gradam	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	13	nsubj	_	NamedEntity=Yes
-15	Grammy	Grammy	PROPN	Noun	Definite=Def|Number=Sing	14	nmod	_	NamedEntity=Yes
+15	Grammy	Grammy	PROPN	Noun	Definite=Def|Foreign=Yes|Number=Sing	14	nmod	_	NamedEntity=Yes
 16	le	le	ADP	Simp	_	17	case	_	_
 17	déanaí	déanaí	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	13	obl:tmod	_	SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -226,8 +226,8 @@
 7	ag	ag	ADP	Simp	_	8	case	_	_
 8	Barcó	Barcó	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	4	obl	_	_
 9	(	(	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
-10	de	de	ADP	Simp	_	8	appos	_	NamedEntity=Yes
-11	barra	barra	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
+10	de	de	PART	Pat	PartType=Pat	8	appos	_	NamedEntity=Yes
+11	barra	Barra	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	10	flat:name	_	NamedEntity=Yes
 12	&	&	CCONJ	Coord	_	13	cc	_	NamedEntity=Yes
 13	co	co	NOUN	Abr	Abbr=Yes	10	conj	_	NamedEntity=Yes|SpaceAfter=No
 14	)	)	PUNCT	Punct	_	10	punct	_	_
@@ -329,7 +329,7 @@
 7	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	8	nsubj	_	_
 8	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	1	acl:relcl	_	_
 9	ina	i	ADP	Poss	Number=Plur|Person=3|Poss=Yes	10	case	_	_
-10	magistri	magistri	NOUN	Noun	Case=Nom|Foreign=Yes|Gender=Fem|Number=Plur	8	xcomp:pred	_	_
+10	magistri	magistri	NOUN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Gender=Fem|Number=Plur	8	xcomp:pred	_	_
 11	tráth	tráth	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	8	obl:tmod	_	_
 12	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	13	mark:prt	_	_
 13	bhíodh	bí	VERB	PastImp	Aspect=Imp|Form=Len|Tense=Past	1	csubj:cleft	_	_
@@ -518,7 +518,7 @@
 3	nó	nó	CCONJ	Coord	_	4	cc	_	_
 4	dhó	dó	NUM	Num	Form=Len|NumType=Card	2	conj	_	_
 5	anuas	anuas	ADV	Dir	_	2	advmod	_	_
-6	amháin	amháin	ADJ	Adj	Degree=Pos	2	amod	_	_
+6	amháin	amháin	ADJ	Adj	Degree=Pos	2	advmod	_	_
 7	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	8	mark:prt	_	_
 8	thosaigh	tosaigh	VERB	VTI	Form=Len|Mood=Ind|Tense=Past	2	csubj:cleft	_	_
 9	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	8	nsubj	_	_
@@ -644,8 +644,8 @@
 8	,	,	PUNCT	Punct	_	4	punct	_	_
 9	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	10	mark:prt	_	_
 10	deir	abair	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
-11	Cumann	cumann	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	NamedEntity=Yes
-12	Fíoncheannaithe	Fíoncheannaithe	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|NounType=Strong|Number=Plur	11	nmod	_	NamedEntity=Yes
+11	Cumann	cumann	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	10	nsubj	_	NamedEntity=Yes
+12	Fíoncheannaithe	fíoncheannaí	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	11	nmod	_	NamedEntity=Yes
 13	Bhaile	Baile	PROPN	Noun	Definite=Def|Form=Len|Gender=Masc|Number=Sing	11	nmod	_	NamedEntity=Yes
 14	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	14	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -675,8 +675,8 @@
 12	seoladh	seol	VERB	VTI	Mood=Ind|Person=0|Tense=Past	5	acl:relcl	_	_
 13	chuig	chuig	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	gCúirt	cúirt	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
-16	Chéadchéime	céadchéim	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
+15	gCúirt	cúirt	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	12	obl	_	NamedEntity=Yes
+16	Chéadchéime	céadchéim	NOUN	Noun	Case=Gen|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
 17	a	a	PART	Inf	PartType=Inf	18	mark	_	_
 18	thaisceadh	taisceadh	NOUN	Noun	Form=Len|VerbForm=Inf	4	xcomp	_	_
 19	de	de	ADP	Simp	_	20	case	_	_
@@ -717,8 +717,8 @@
 54	seoladh	seol	VERB	VTI	Mood=Ind|Person=0|Tense=Past	47	acl:relcl	_	_
 55	chuig	chuig	ADP	Simp	_	57	case	_	_
 56	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	57	det	_	_
-57	gCúirt	cúirt	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	54	nmod	_	NamedEntity=Yes
-58	Bhreithiúnais	breithiúnas	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
+57	gCúirt	cúirt	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Fem|Number=Sing	54	nmod	_	NamedEntity=Yes
+58	Bhreithiúnais	breithiúnas	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	57	nmod	_	NamedEntity=Yes
 59	a	a	PART	Inf	PartType=Inf	60	mark	_	_
 60	thaisceadh	taisceadh	NOUN	Noun	Form=Len|VerbForm=Inf	46	xcomp	_	_
 61	de	de	ADP	Simp	_	62	case	_	_
@@ -842,8 +842,8 @@
 11	leanas	lean	VERB	VTI	Mood=Ind|PronType=Rel|Tense=Pres	8	acl:relcl	_	_
 12	ó	ó	ADP	Simp	_	13	case	_	_
 13	Sheán	Seán	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	8	nmod	_	NamedEntity=Yes
-14	Sheáin	Seáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
-15	Í	í	PRON	Pers	Gender=Fem|Number=Sing|Person=3	13	flat:name	_	NamedEntity=Yes
+14	Sheáin	Seáin	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	13	flat:name	_	NamedEntity=Yes
+15	Í	uí	PART	Pat	PartType=Pat	13	flat:name	_	NamedEntity=Yes
 16	Chearnaigh	Cearnaigh	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	13	flat:name	_	NamedEntity=Yes
 17	ar	ar	ADP	Simp	_	19	case	_	_
 18	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	19	det	_	_
@@ -1178,7 +1178,7 @@
 57	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	58	det	_	_
 58	dearbhú	dearbhú	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	56	obj	_	_
 59	de	de	ADP	Simp	_	60	case	_	_
-60	bhun	bun	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	56	obl	_	_
+60	bhun	bun	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	56	obl	_	_
 61	Airteagal	airteagal	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	60	nmod	_	_
 62	IV	IV	NUM	Num	NumType=Card	61	nmod	_	_
 63	nó	nó	CCONJ	Coord	_	65	cc	_	_
@@ -1189,7 +1189,7 @@
 68	in	i	ADP	Simp	_	69	case	_	_
 69	iúl	iúl	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	65	obl	_	_
 70	de	de	ADP	Simp	_	71	case	_	_
-71	bhun	bun	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	65	obl	_	_
+71	bhun	bun	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	65	obl	_	_
 72	Airteagal	airteagal	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	71	nmod	_	_
 73	VI	VI	NUM	Num	NumType=Card	72	nmod	_	_
 74	agus	agus	CCONJ	Coord	_	76	cc	_	_
@@ -2040,9 +2040,9 @@
 7	Chorcaí	Corcaigh	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	6	nmod	_	NamedEntity=Yes|SpaceAfter=No
 8	,	,	PUNCT	Punct	_	6	punct	_	_
 9	'	'	PUNCT	Punct	_	10	punct	_	SpaceAfter=No
-10	that	that	PRON	Dem	Foreign=Yes|PronType=Dem	1	obj	_	_
-11	general	general	ADJ	Noun	Foreign=Yes	10	flat:foreign	_	_
-12	Jail-Deliverer	Jail-Deliverer	NOUN	Noun	Foreign=Yes	10	flat:foreign	_	SpaceAfter=No
+10	that	that	X	_	Foreign=Yes	1	obj	_	_
+11	general	general	X	_	Foreign=Yes	10	flat:foreign	_	_
+12	Jail-Deliverer	Jail-Deliverer	X	_	Foreign=Yes	10	flat:foreign	_	SpaceAfter=No
 13	'	'	PUNCT	Punct	_	10	punct	_	_
 14	air	ar	ADP	Prep	Gender=Masc|Number=Sing|Person=3	1	obl:prep	_	_
 15	le	le	ADP	Cmpd	PrepForm=Cmpd	18	case	_	_
@@ -2138,8 +2138,8 @@
 7	i	i	ADP	Cmpd	PrepForm=Cmpd	10	case	_	_
 8	mbun	bun	NOUN	Cmpd	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing|PrepForm=Cmpd	7	fixed	_	_
 9	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Roinne	roinn	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	obl	_	NamedEntity=Yes
-11	Oideachais	oideachas	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes|SpaceAfter=No
+10	Roinne	roinn	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	4	obl	_	NamedEntity=Yes
+11	Oideachais	oideachas	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	nuair	nuair	SCONJ	Subord	_	15	mark	_	_
 14	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	15	mark:prt	_	_
@@ -3186,7 +3186,7 @@
 6	go	go	ADP	Simp	_	7	case	_	_
 7	hIarthar	iarthar	NOUN	Noun	Case=Nom|Definite=Def|Form=HPref|Gender=Masc|Number=Sing	5	nmod	_	NamedEntity=Yes
 8	Bhéal	Béal	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	7	nmod	_	NamedEntity=Yes
-9	Feirste	Feirste	PROPN	Noun	Definite=Def|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
+9	Feirste	Feirste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	8	nmod	_	NamedEntity=Yes|SpaceAfter=No
 10	?	?	PUNCT	?	_	2	punct	_	_
 
 # sent_id = 131
@@ -3339,7 +3339,7 @@
 9	pobal	pobal	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	_
 10	Gaeilge	Gaeilge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	9	nmod	_	_
 11	Bhéal	Béal	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	9	nmod	_	NamedEntity=Yes
-12	Feirste	Feirste	PROPN	Noun	Definite=Def|Number=Sing	11	nmod	_	NamedEntity=Yes
+12	Feirste	Feirste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	11	nmod	_	NamedEntity=Yes
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	obair	obair	NOUN	Noun	VerbForm=Vnoun	8	xcomp	_	_
 15	go	go	PART	Ad	PartType=Ad	16	mark:prt	_	_
@@ -4070,7 +4070,7 @@
 13	i	i	ADP	Simp	_	14	case	_	_
 14	rang	rang	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	_
 15	1	1	NUM	Num	_	14	nmod	_	_
-16	Bunscoil	bunscoil	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
+16	Bunscoil	bunscoil	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	14	nmod	_	_
 17	Mhic	mac	PART	Pat	Form=Len|PartType=Pat	16	nmod	_	NamedEntity=Yes
 18	Reachtain	Reachtain	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	17	flat:name	_	NamedEntity=Yes
 19	i	i	ADP	Simp	_	20	case	_	_
@@ -4420,8 +4420,8 @@
 4	na	an	DET	Art	Definite=Def|Number=Plur|PronType=Art	5	det	_	_
 5	ranganna	rang	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Plur	1	obl	_	_
 6	ag	ag	ADP	Simp	_	8	case	_	_
-7	Bishopsgate	Bishopsgate	X	Foreign	Foreign=Yes	5	nmod	_	NamedEntity=Yes
-8	Institute	Institute	X	Foreign	Foreign=Yes	7	flat:foreign	_	NamedEntity=Yes
+7	Bishopsgate	Bishopsgate	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	5	nmod	_	NamedEntity=Yes
+8	Institute	Institute	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	7	flat	_	NamedEntity=Yes
 9	ar	ar	ADP	Simp	_	11	case	_	_
 10	7	7	NUM	Num	_	1	obl:tmod	_	NamedEntity=Yes
 11	Deireadh	Deireadh	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	10	flat	_	NamedEntity=Yes
@@ -4638,7 +4638,7 @@
 2	meathdhorchadas	meathdhorchadas	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	5	obl	_	_
 3	sin	sin	DET	Det	PronType=Dem	2	det	_	_
 4	d'	do	PART	Vb	PartType=Vb	5	mark:prt	_	SpaceAfter=No
-5	fhéadas	féad	VERB	VTI	Form=Len|Mood=Ind|PronType=Rel|Tense=Past	0	root	_	_
+5	fhéadas	féad	VERB	VTI	Form=Len|Mood=Ind|Number=Sing|Person=1|Tense=Past	0	root	_	_
 6	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	7	det	_	_
 7	stáitse	stáitse	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	obj	_	_
 8	a	a	PART	Inf	PartType=Inf	9	mark	_	_
@@ -4647,7 +4647,7 @@
 11	ar	ar	ADP	Simp	_	12	case	_	_
 12	éigean	éigean	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	9	obl	_	_
 13	faoina	faoi	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	case	_	_
-14	shoilse	solas	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Plur	5	obl	_	_
+14	shoilse	solas	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Plur	9	obl	_	_
 15	fanna	fann	ADJ	Adj	Case=Nom|Gender=Masc|NounType=NotSlender|Number=Plur	14	amod	_	_
 16	néoin	néon	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
 17	.	.	PUNCT	.	_	5	punct	_	_
@@ -5156,7 +5156,7 @@
 8	adúirt	abair	VERB	VTI	Mood=Ind|Tense=Past	0	root	_	_
 9	Jóín	Jóín	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	8	nsubj	_	NamedEntity=Yes
 10	Joe	Joe	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes
-11	Labhráis	Labhrás	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
+11	Labhráis	Labhrás	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	9	flat:name	_	NamedEntity=Yes|SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
 13	ag	ag	ADP	Simp	_	14	case	_	_
 14	brú	brú	NOUN	Noun	VerbForm=Vnoun	9	xcomp	_	_
@@ -5219,7 +5219,7 @@
 23	sí	sí	PRON	Pers	Gender=Fem|Number=Sing|Person=3	22	nsubj	_	_
 24	dhá	do	ADP	Poss	Form=Len|Gender=Fem|Number=Sing|Person=3|Poss=Yes|PronType=Prs	25	case	_	_
 25	coinneáil	coinneáil	NOUN	Noun	Definite=Def|VerbForm=Inf	22	xcomp:pred	_	_
-26	dúinte	dúinte	ADJ	Adj	VerbForm=Part	25	xcomp:pred	_	_
+26	dúinte	dúnta	ADJ	Adj	VerbForm=Part	25	xcomp:pred	_	_
 27	le	le	ADP	Simp	_	28	case	_	_
 28	foréigean	foréigean	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	26	obl	_	SpaceAfter=No
 29	'	'	PUNCT	Punct	_	28	punct	_	_
@@ -5362,7 +5362,7 @@
 11	shantú	santú	NOUN	Noun	Definite=Def|Form=Len|VerbForm=Inf	9	xcomp	_	_
 12	ag	ag	ADP	Simp	_	13	case	_	_
 13	Béal	Béal	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	11	obl	_	NamedEntity=Yes
-14	Feirste	Feirste	PROPN	Noun	Definite=Def	13	nmod	_	NamedEntity=Yes
+14	Feirste	Feirste	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	13	nmod	_	NamedEntity=Yes
 15	le	le	SCONJ	Subord	_	17	mark	_	_
 16	go	go	SCONJ	Subord	_	15	fixed	_	_
 17	dtig	tar	VERB	VI	Form=Ecl|Mood=Ind|Tense=Pres	2	advcl	_	_
@@ -5372,8 +5372,8 @@
 21	ar	ar	ADP	Simp	_	22	case	_	_
 22	chomhchéim	comhchéim	NOUN	Noun	Case=Nom|Form=Len|Gender=Fem|Number=Sing	20	xcomp:pred	_	_
 23	le	le	ADP	Simp	_	24	case	_	_
-24	Quartier	Quartier	X	Foreign	Foreign=Yes	22	nmod	_	NamedEntity=Yes
-25	Latin	Latin	X	Foreign	Foreign=Yes	24	flat:foreign	_	NamedEntity=Yes
+24	Quartier	Quartier	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	22	nmod	_	NamedEntity=Yes
+25	Latin	Latin	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	24	flat	_	NamedEntity=Yes
 26	Phárais	Páras	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
 27	.	.	PUNCT	.	_	2	punct	_	_
 
@@ -5430,7 +5430,7 @@
 22	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	23	obl:tmod	_	_
 23	bheidh	bí	VERB	FutInd	Form=Len|Mood=Ind|Tense=Fut	21	acl:relcl	_	_
 24	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	25	det	_	NamedEntity=Yes
-25	Páirtí	páirtí	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	NamedEntity=Yes
+25	Páirtí	páirtí	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	23	nsubj	_	NamedEntity=Yes
 26	Glas	glas	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	25	amod	_	NamedEntity=Yes
 27	i	i	ADP	Simp	_	28	case	_	_
 28	gcomhrialtas	comhrialtas	NOUN	Noun	Case=Nom|Form=Ecl|Gender=Masc|Number=Sing	23	xcomp:pred	_	_
@@ -5517,9 +5517,9 @@
 15	laghdaigh	laghdaigh	VERB	VTI	Mood=Ind|Tense=Past	9	acl:relcl	_	_
 16	muinín	muinín	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	15	obj	_	_
 17	in	i	ADP	Simp	_	18	case	_	_
-18	Óglaigh	óglach	NOUN	Noun	Case=Nom|Gender=Masc|Number=Plur	16	nmod	_	_
+18	Óglaigh	óglach	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Plur	16	nmod	_	_
 19	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	20	det	_	_
-20	IRA	IRA	PROPN	Abr	Abbr=Yes	18	nmod	_	_
+20	IRA	IRA	PROPN	Abr	Abbr=Yes|Definite=Def	18	nmod	_	_
 21	agus	agus	CCONJ	Coord	_	23	cc	_	_
 22	a	a	PART	Vb	Form=Direct|PartType=Vb|PronType=Rel	23	nsubj	_	_
 23	chuidigh	cuidigh	VERB	VI	Form=Len|Mood=Ind|Tense=Past	15	conj	_	_
@@ -5630,7 +5630,7 @@
 52	is	is	PART	Sup	PartType=Sup	53	mark:prt	_	_
 53	fuaire	fuar	ADJ	Adj	Degree=Cmp,Sup	48	list	_	_
 54	bán	bán	ADJ	Adj	Degree=Pos	10	list	_	_
-55	white	white	ADJ	Adj	Foreign=Yes	54	appos	_	_
+55	white	white	X	Foreign	Foreign=Yes	54	appos	_	_
 56	níos	níos	PART	Cmp	PartType=Comp	57	mark:prt	_	_
 57	báine	bán	ADJ	Adj	Degree=Cmp,Sup	54	list	_	_
 58	is	is	PART	Sup	PartType=Sup	59	mark:prt	_	_
@@ -5684,7 +5684,7 @@
 17	Chulainn	Culann	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	17	nmod	_	NamedEntity=Yes
 19	Ard	Ard	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	18	nmod	_	NamedEntity=Yes
-20	Mhacha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Form=Len	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
+20	Mhacha	Macha	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Fem|Number=Sing	19	nmod	_	NamedEntity=Yes|SpaceAfter=No
 21	.	.	PUNCT	.	_	3	punct	_	_
 
 # sent_id = 235
@@ -6177,7 +6177,7 @@
 
 # sent_id = 246
 # text = ras Nua-Ealaíne na hÉireann (Bhaile Átha Cliath) An Ceoláras Náisiúnta (Bhaile Átha Cliath) Gailearaí Náisiúnta na hÉireann (Bhaile Átha Cliath) Músaem na Staire Nádúrtha (Bhaile Átha Cliath) Leabharlann Náisiúnta na hÉireann (Bhaile Átha Cliath) Ard-Mhúsaem na hÉireann, Dún Uí Choileáin (Bhaile Átha Cliath) Ard-Mhúsaem na hÉireann, Sráid Chill Dara (Bhaile Átha Cliath) National Photographic Archive (Dublin).
-1	ras	rás	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+1	ras	áras	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|Typo=Yes	0	root	_	_
 2	Nua-Ealaíne	nua-ealaín	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	NamedEntity=Yes
 4	hÉireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Form=HPref|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes
@@ -6203,9 +6203,9 @@
 24	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	24	nmod	_	NamedEntity=Yes|SpaceAfter=No
 26	)	)	PUNCT	Punct	_	23	punct	_	_
-27	Músaem	músaem	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
+27	Músaem	músaem	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	list	_	NamedEntity=Yes
 28	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	NamedEntity=Yes
-29	Staire	stair	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	27	nmod	_	NamedEntity=Yes
+29	Staire	stair	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	27	nmod	_	NamedEntity=Yes
 30	Nádúrtha	nádúrtha	ADJ	Adj	Case=Gen|Gender=Fem|Number=Sing	29	amod	_	NamedEntity=Yes
 31	(	(	PUNCT	Punct	_	32	punct	_	SpaceAfter=No
 32	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	27	nmod	_	NamedEntity=Yes
@@ -6239,7 +6239,7 @@
 60	,	,	PUNCT	Punct	_	61	punct	_	_
 61	Sráid	sráid	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	57	nmod	_	NamedEntity=Yes
 62	Chill	Cill	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	61	nmod	_	NamedEntity=Yes
-63	Dara	Dara	PROPN	Noun	Definite=Def	62	nmod	_	NamedEntity=Yes
+63	Dara	Dair	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	62	nmod	_	NamedEntity=Yes
 64	(	(	PUNCT	Punct	_	65	punct	_	SpaceAfter=No
 65	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	61	nmod	_	NamedEntity=Yes
 66	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	65	nmod	_	NamedEntity=Yes
@@ -6754,14 +6754,14 @@
 156	réir	réir	NOUN	Cmpd	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PrepForm=Cmpd	155	fixed	_	_
 157	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	158	det	_	_
 158	foirmle	foirmle	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	154	obl	_	_
-159	A	a	X	Abr	Abbr=Yes	158	nmod	_	_
-160	plus	plus	X	Foreign	Foreign=Yes	159	flat:foreign	_	_
-161	IRP25,000	IRP25,000	NUM	Num	_	159	flat:foreign	_	_
+159	A	A	NUM	Item	Abbr=Yes	158	nmod	_	_
+160	plus	plus	CCONJ	_	_	161	cc	_	_
+161	IRP25,000	IRP25,000	NUM	Num	_	152	conj	_	_
 162	i	i	ADP	Simp	_	163	case	_	_
 163	gcás	cás	NOUN	Noun	Case=Nom|Form=Ecl|Gender=Masc|Number=Sing	154	obl	_	_
 164	gurb	is	AUX	Cop	Form=VF|Tense=Pres|VerbForm=Cop	165	cop	_	_
 165	é	é	PRON	Pers	Gender=Masc|Number=Sing|Person=3	163	nmod	_	_
-166	A	a	X	Abr	Abbr=Yes	154	advcl	_	_
+166	A	a	NUM	Item	Abbr=Yes	154	advcl	_	_
 167	méid	méid	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	165	nsubj	_	_
 168	bhrabúis	brabús	NOUN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	167	nmod	_	_
 169	nó	nó	CCONJ	Coord	_	170	cc	_	_
@@ -6843,7 +6843,7 @@
 56	in	in	ADP	Cmpd	PrepForm=Cmpd	58	case	_	_
 57	aghaidh	aghaidh	NOUN	Cmpd	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PrepForm=Cmpd	56	fixed	_	_
 58	Phort	Port	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	55	nmod	_	NamedEntity=Yes
-59	Láirge	Láirge	PROPN	Noun	Definite=Def	58	nmod	_	NamedEntity=Yes
+59	Láirge	Láirge	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	58	nmod	_	NamedEntity=Yes
 60	dha	dó	NUM	Num	Form=Len|NumType=Card|Typo=Yes	61	nummod	_	_
 61	sheachtain	seachtain	NOUN	Noun	Case=Nom|Form=Len|Gender=Fem|Number=Sing	43	obl:tmod	_	_
 62	ó	ó	ADP	Simp	_	63	case	_	_
@@ -7001,7 +7001,7 @@
 1	Tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
 2	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	1	nsubj	_	_
 3	á	do	ADP	Poss	Number=Plur|Person=3|Poss=Yes|PronType=Prs	4	case	_	_
-4	gcothú	cothú	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing|VerbForm=Inf	1	xcomp	_	_
+4	gcothú	cothú	NOUN	Noun	Definite=Def|Form=Ecl|VerbForm=Inf	1	xcomp	_	_
 5	ar	ar	ADP	Simp	_	7	case	_	_
 6	na	an	DET	Art	Definite=Def|Number=Plur|PronType=Art	7	det	_	_
 7	cuileoga	cuileog	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Plur	4	nmod	_	_
@@ -7122,8 +7122,8 @@
 4	sé	sé	PRON	Pers	Gender=Masc|Number=Sing|Person=3	3	nsubj	_	_
 5	ar	ar	ADP	Simp	_	6	case	_	_
 6	chumas	cumas	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	3	obl	_	_
-7	Fhinn	Fionn	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	10	obj	_	NamedEntity=Yes
-8	Diarmaid	Diarmaid	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	7	flat:name	_	NamedEntity=Yes
+7	Fhinn	Fionn	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	10	obj	_	NamedEntity=Yes
+8	Diarmaid	Diarmaid	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	10	obj	_	NamedEntity=Yes
 9	a	a	PART	Inf	PartType=Inf	10	mark	_	_
 10	leigheas	leigheas	NOUN	Noun	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
 11	,	,	PUNCT	Punct	_	12	punct	_	_
@@ -7302,14 +7302,14 @@
 21	aon	aon	DET	Det	PronType=Ind	22	det	_	_
 22	bhriseadh	briseadh	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	15	xcomp:pred	_	_
 23	idir	idir	ADP	Simp	_	24	case	_	_
-24	RnaG	RnaG	PROPN	Abr	Abbr=Yes	22	nmod	_	_
+24	RnaG	RnaG	PROPN	Abr	Abbr=Yes|Definite=Def	22	nmod	_	_
 25	agus	agus	CCONJ	Coord	_	28	cc	_	_
 26	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	28	det	_	_
 27	'	'	PUNCT	Punct	_	28	punct	_	SpaceAfter=No
 28	mháthair-chomhlacht	máthairchomhlacht	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	conj	_	SpaceAfter=No
 29	'	'	PUNCT	Punct	_	28	punct	_	_
 30	in	i	ADP	Simp	_	31	case	_	_
-31	RTÉ	RTÉ	PROPN	Abr	Abbr=Yes	28	nmod	_	SpaceAfter=No
+31	RTÉ	RTÉ	PROPN	Abr	Abbr=Yes|Definite=Def	28	nmod	_	SpaceAfter=No
 32	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 284
@@ -7371,17 +7371,17 @@
 2	gearán	gearán	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	1	nsubj	_	_
 3	déanta	déanta	ADJ	Adj	VerbForm=Part	1	xcomp:pred	_	_
 4	ag	ag	ADP	Simp	_	5	case	_	_
-5	Unison	Unison	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+5	Unison	Unison	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	3	obl	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	7	punct	_	_
-7	ceardchumann	ceardchumann	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	5	appos	_	_
-8	lucht	lucht	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	7	nmod	_	_
+7	ceardchumann	ceardchumann	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	5	appos	_	_
+8	lucht	lucht	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	7	nmod	_	_
 9	na	an	DET	Art	Case=Gen|Definite=Def|Number=Plur|PronType=Art	10	det	_	_
 10	mbónaí	bóna	NOUN	Noun	Case=Gen|Definite=Def|Form=Ecl|Gender=Masc|NounType=Strong|Number=Plur	8	nmod	_	_
 11	bána	bán	ADJ	Adj	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	10	amod	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	15	punct	_	_
 13	leis	le	ADP	Simp	_	15	case	_	_
 14	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	15	det	_	_
-15	gCoimisiún	coimisiún	PROPN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
+15	gCoimisiún	coimisiún	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	3	obl	_	NamedEntity=Yes
 16	um	um	ADP	Simp	_	17	case	_	NamedEntity=Yes
 17	Comhionannas	comhionannas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	15	nmod	_	NamedEntity=Yes
 18	Ciníoch	ciníoch	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	17	amod	_	_
@@ -7506,7 +7506,7 @@
 4	ar	ar	ADP	Simp	_	5	case	_	_
 5	shaíocht	saíocht	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	1	obl	_	_
 6	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Sean-Ghréige	Sean-Ghréig	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem	5	nmod	_	_
+7	Sean-Ghréige	Sean-Ghréig	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	5	nmod	_	_
 8	ná	nach	PART	Vb	Form=Direct|PartType=Vb|Polarity=Neg|PronType=Rel	9	nsubj	_	_
 9	fuair	faigh	VERB	VT	Mood=Ind|Polarity=Neg|Tense=Past	3	acl:relcl	_	_
 10	glacadh	glacadh	NOUN	Noun	VerbForm=Inf	9	obj	_	_
@@ -7714,7 +7714,7 @@
 19	faoin	faoi	ADP	Art	Number=Sing|PronType=Art	20	case	_	_
 20	ghalar	galar	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	18	obl	_	_
 21	marfach	marfach	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	20	amod	_	_
-22	SEIF	SEIF	PROPN	Abr	Abbr=Yes	20	nmod	_	SpaceAfter=No
+22	SEIF	SEIF	PROPN	Abr	Abbr=Yes|Definite=Def	20	nmod	_	SpaceAfter=No
 23	.	.	PUNCT	.	_	8	punct	_	_
 
 # sent_id = 300
@@ -7824,7 +7824,7 @@
 16	éadaitheoir	éadaitheoir	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	11	nmod	_	_
 17	olla	olann	NOUN	Noun	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	_
 18	i	i	ADP	Simp	_	19	case	_	_
-19	Liobartaí	Liobartaí	PROPN	Noun	Definite=Def	10	obl	_	_
+19	Liobartaí	Liobartaí	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	10	obl	_	_
 20	Bhaile	Baile	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	NamedEntity=Yes
 21	Átha	Átha	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	20	nmod	_	NamedEntity=Yes
 22	Cliath	Cliath	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|NounType=Weak|Number=Plur	21	nmod	_	NamedEntity=Yes|SpaceAfter=No
@@ -7832,7 +7832,7 @@
 24	gar	gar	ADJ	Adj	Degree=Pos	20	amod	_	_
 25	do	do	ADP	Simp	_	26	case	_	_
 26	Theampall	teampall	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Sing	24	obl	_	NamedEntity=Yes
-27	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc	26	nmod	_	NamedEntity=Yes|SpaceAfter=No
+27	Phádraig	Pádraig	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	26	nmod	_	NamedEntity=Yes|SpaceAfter=No
 28	,	,	PUNCT	Punct	_	29	punct	_	_
 29	rud	rud	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	10	parataxis	_	_
 30	annamh	annamh	ADJ	Adj	Case=Nom|Gender=Masc|Number=Sing	29	amod	_	_
@@ -8005,8 +8005,8 @@
 # sent_id = 312
 # text = (a) Ospideul meán-suidhte chun cásanna chun Leighis agus Máin-liaghais do leigheas.
 1	(a)	(a)	NUM	Item	_	2	list	_	_
-2	Ospideul	ospideul	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-3	meán-suidhte	meán-suidhte	ADJ	Adj	VerbForm=Part	2	xcomp:pred	_	_
+2	Ospideul	ospidéal	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+3	meán-suidhte	meánsuite	ADJ	Adj	VerbForm=Part	2	xcomp:pred	_	_
 4	chun	chun	ADP	Simp	_	5	case	_	_
 5	cásanna	cás	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Strong|Number=Plur	2	nmod	_	_
 6	chun	chun	ADP	Simp	_	7	case	_	_
@@ -8444,7 +8444,7 @@
 31	The	the	X	Foreign	Foreign=Yes	14	obl	_	_
 32	Limerick	Limerick	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
 33	/	/	PUNCT	Punct	_	34	punct	_	_
-34	Cork	Cork	PROPN	Foreign	Foreign=Yes	31	flat:foreign	_	_
+34	Cork	Cork	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
 35	Border	Border	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
 36	in	in	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
 37	the	the	X	Foreign	Foreign=Yes	31	flat:foreign	_	_
@@ -8547,11 +8547,11 @@
 10	gcomhluadar	comhluadar	NOUN	Noun	Case=Nom|Definite=Def|Form=Ecl|Gender=Masc|Number=Sing	7	nmod	_	_
 11	i	i	ADP	Simp	_	12	case	_	_
 12	Mhainistir	mainistir	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	10	nmod	_	NamedEntity=Yes
-13	Éimhín	Éimhín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc	12	nmod	_	NamedEntity=Yes|SpaceAfter=No
+13	Éimhín	Éimhín	PROPN	Noun	Case=Gen|Definite=Def|Gender=Masc|Number=Sing	12	nmod	_	NamedEntity=Yes|SpaceAfter=No
 14	,	,	PUNCT	Punct	_	15	punct	_	_
 15	Co.	contae	NOUN	Abr	Abbr=Yes|Definite=Def	12	nmod	_	NamedEntity=Yes
 16	Chill	Cill	PROPN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Fem|Number=Sing	15	nmod	_	NamedEntity=Yes
-17	Dara	Dara	PROPN	Noun	Definite=Def	16	nmod	_	NamedEntity=Yes
+17	Dara	Dair	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	16	nmod	_	NamedEntity=Yes
 18	agus	agus	CCONJ	Coord	_	19	cc	_	_
 19	ina	i	ADP	Poss	Gender=Masc|Number=Sing|Person=3|Poss=Yes	7	conj	_	_
 20	phríomhoide	príomhoide	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	19	nmod	_	_
@@ -9049,9 +9049,9 @@
 11	go	go	PART	Ad	PartType=Ad	12	mark:prt	_	_
 12	breá	breá	ADJ	Adj	Degree=Pos	10	advmod	_	_
 13	le	le	ADP	Simp	_	14	case	_	_
-14	feachtas	feachtas	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	10	obl	_	_
+14	feachtas	feachtas	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	10	obl	_	_
 15	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	16	det	_	_
-16	IDA	IDA	PROPN	Abr	Abbr=Yes	14	nmod	_	_
+16	IDA	IDA	PROPN	Abr	Abbr=Yes|Definite=Def	14	nmod	_	_
 17	-	-	PUNCT	Punct	_	18	punct	_	_
 18	meastar	meas	VERB	VTI	Mood=Ind|Person=0|Tense=Pres	6	parataxis	_	_
 19	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	21	cop	_	_
@@ -9099,7 +9099,7 @@
 # sent_id = 351
 # text = An UUP.
 1	An	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	2	det	_	_
-2	UUP	UUP	PROPN	Abr	Abbr=Yes	0	root	_	SpaceAfter=No
+2	UUP	UUP	PROPN	Abr	Abbr=Yes|Definite=Def	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	.	_	2	punct	_	_
 
 # sent_id = 352
@@ -9129,7 +9129,7 @@
 4	thiar	thiar	ADV	Dir	_	3	advmod	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	7	punct	_	_
 6	a	a	PART	Voc	PartType=Voc	7	case:voc	_	_
-7	Sheáin	Seán	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc	1	vocative	_	SpaceAfter=No
+7	Sheáin	Seán	PROPN	Noun	Case=Voc|Definite=Def|Form=Len|Gender=Masc|Number=Sing	1	vocative	_	SpaceAfter=No
 8	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 355
@@ -9528,7 +9528,7 @@
 # sent_id = 373
 # text = Rud ab fhusa a dhéanamh...
 1	Rud	rud	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	5	obj	_	_
-2	ab	is	PART	Sup	Form=VF|PartType=Sup	3	mark:prt	_	_
+2	ab	is	PART	Sup	Form=VF|PartType=Sup|Tense=Past|VerbForm=Cop	3	mark:prt	_	_
 3	fhusa	furasta	ADJ	Adj	Degree=Cmp,Sup|Form=Len	1	amod	_	_
 4	a	a	PART	Inf	PartType=Inf	5	mark	_	_
 5	dhéanamh	déanamh	NOUN	Noun	Form=Len|VerbForm=Inf	0	root	_	SpaceAfter=No
@@ -9829,22 +9829,22 @@
 6	acu	ag	ADP	Prep	Number=Plur|Person=3	5	obl:prep	_	_
 7	bhí	bí	VERB	PastInd	Form=Len|Mood=Ind|Tense=Past	0	root	_	_
 8	Cor	cor	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
-9	Ochtar	ochtar	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	8	flat:foreign	_	SpaceAfter=No
+9	Ochtar	ochtar	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	8	nmod	_	SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
-11	Gay	Gay	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
-12	Gordons	Gordons	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	11	flat:foreign	_	SpaceAfter=No
+11	Gay	Gay	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	8	conj	_	_
+12	Gordons	Gordons	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	11	flat	_	SpaceAfter=No
 13	,	,	PUNCT	Punct	_	14	punct	_	_
-14	Highland	Highland	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
-15	Fling	Fling	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	14	flat:foreign	_	SpaceAfter=No
+14	Highland	Highland	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	8	conj	_	_
+15	Fling	Fling	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	14	flat	_	SpaceAfter=No
 16	,	,	PUNCT	Punct	_	17	punct	_	_
-17	Sword	Sword	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
-18	Dance	Dance	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	17	flat:foreign	_	SpaceAfter=No
+17	Sword	Sword	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	8	conj	_	_
+18	Dance	Dance	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	17	flat	_	SpaceAfter=No
 19	,	,	PUNCT	Punct	_	20	punct	_	_
-20	Dashing	Dashing	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	9	conj	_	_
-21	White	White	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	20	flat:foreign	_	_
-22	Sargents	Sargents	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	21	flat:foreign	_	_
+20	Dashing	Dashing	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	8	conj	_	_
+21	White	White	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	20	flat	_	_
+22	Sargents	Sargents	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	20	flat	_	_
 23	agus	agus	CCONJ	Coord	_	24	cc	_	_
-24	mórán	mórán	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	9	conj	_	_
+24	mórán	mórán	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	8	conj	_	_
 25	eile	eile	DET	Det	PronType=Dem	24	det	_	_
 26	de	de	ADP	Simp	_	27	case	_	_
 27	dhamhsaí	damhsa	NOUN	Noun	Case=Nom|Definite=Def|Form=Len|Gender=Masc|Number=Plur	24	nmod	_	_
@@ -9948,7 +9948,7 @@
 5	Eo	Eo	PROPN	Noun	Definite=Def|Number=Sing	4	nmod	_	NamedEntity=Yes
 6	féin	féin	PRON	Ref	Reflex=Yes	4	nmod	_	_
 7	-	-	PUNCT	Punct	_	8	punct	_	_
-8	Gaeltacht	Gaeltacht	PROPN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	4	nmod	_	_
+8	Gaeltacht	Gaeltacht	PROPN	Noun	Case=Nom|Gender=Fem|Number=Sing	4	nmod	_	_
 9	atá	bí	VERB	PresInd	Form=Direct|Mood=Ind|PronType=Rel|Tense=Pres	8	acl:relcl	_	_
 10	chomh	chomh	ADV	Its	_	11	advmod	_	_
 11	scaipthe	scaipthe	ADJ	Adj	Degree=Pos	9	xcomp:pred	_	_
@@ -10051,7 +10051,7 @@
 1	Ar	ar	ADP	Simp	_	4	case	_	_
 2	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	4	det	_	_
 3	gcéad	céad	NUM	Num	Form=Ecl|NumType=Ord	4	amod	_	_
-4	dul	dul	NOUN	Noun	Definite=Def|VerbForm=Inf	7	obl	_	_
+4	dul	dul	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	7	obl	_	_
 5	síos	síos	ADV	Dir	_	4	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	Punct	_	4	punct	_	_
 7	tá	bí	VERB	PresInd	Mood=Ind|Tense=Pres	0	root	_	_
@@ -10259,7 +10259,7 @@
 16	,	,	PUNCT	Punct	_	17	punct	_	_
 17	Cultúir	cultúr	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	15	conj	_	NamedEntity=Yes|SpaceAfter=No
 18	,	,	PUNCT	Punct	_	19	punct	_	_
-19	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	15	conj	_	NamedEntity=Yes
+19	Gaeltachta	Gaeltacht	PROPN	Noun	Case=Gen|Gender=Fem|Number=Sing	15	conj	_	NamedEntity=Yes
 20	agus	agus	CCONJ	Coord	_	21	cc	_	NamedEntity=Yes
 21	Oileán	oileán	NOUN	Noun	Case=Gen|Gender=Masc|NounType=Weak|Number=Plur	15	conj	_	NamedEntity=Yes|SpaceAfter=No
 22	.	.	PUNCT	.	_	1	punct	_	_
@@ -11104,19 +11104,19 @@
 2	Ordanáis	ordanás	NOUN	Noun	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	NamedEntity=Yes
 3	Éireann	Éire	PROPN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	1	nmod	_	NamedEntity=Yes|SpaceAfter=No
 4	,	,	PUNCT	Punct	_	5	punct	_	_
-5	Rehab	Rehab	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
-6	Group	Group	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	5	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
+5	Rehab	Rehab	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	1	conj	_	NamedEntity=Yes
+6	Group	Group	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	5	flat	_	NamedEntity=Yes|SpaceAfter=No
 7	,	,	PUNCT	Punct	_	8	punct	_	_
-8	Irish	Irish	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
-9	Shell	Shell	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	8	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
+8	Irish	Irish	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	1	conj	_	NamedEntity=Yes
+9	Shell	Shell	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	8	flat	_	NamedEntity=Yes|SpaceAfter=No
 10	,	,	PUNCT	Punct	_	11	punct	_	_
-11	Sportsfile	Sportsfile	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	SpaceAfter=No
+11	Sportsfile	Sportsfile	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	1	conj	_	SpaceAfter=No
 12	,	,	PUNCT	Punct	_	13	punct	_	_
-13	Tesco	Tesco	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	1	conj	_	NamedEntity=Yes
-14	Ireland	Ireland	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	13	flat:foreign	_	NamedEntity=Yes
+13	Tesco	Tesco	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	1	conj	_	NamedEntity=Yes
+14	Ireland	Ireland	PROPN	Noun	Case=Nom|Definite=Def|Number=Sing	13	flat	_	NamedEntity=Yes
 15	agus	agus	CCONJ	Coord	_	16	cc	_	_
-16	The	the	DET	Foreign	Foreign=Yes	1	conj	_	NamedEntity=Yes
-17	Yard	Yard	PROPN	Foreign	Foreign=Yes	16	flat:foreign	_	NamedEntity=Yes|SpaceAfter=No
+16	The	the	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	1	conj	_	NamedEntity=Yes
+17	Yard	Yard	PROPN	Noun	Case=Nom|Definite=Def|Foreign=Yes|Number=Sing	16	flat	_	NamedEntity=Yes|SpaceAfter=No
 18	.	.	PUNCT	.	_	1	punct	_	_
 
 # sent_id = 436
@@ -11176,7 +11176,7 @@
 11	gur	is	AUX	Cop	Tense=Pres|VerbForm=Cop	12	cop	_	_
 12	bréaga	bréag	NOUN	Noun	Case=Nom|Gender=Fem|Number=Plur	8	csubj:cop	_	_
 13	a	a	DET	Det	Gender=Masc|Number=Sing|Person=3|Poss=Yes	14	nmod:poss	_	_
-14	leath	leath	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	12	nmod	_	_
+14	leath	leath	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	12	nsubj	_	_
 15	dá	de	ADP	_	PronType=Rel	14	nmod	_	_
 16	bhfuil	bí	VERB	PresInd	Form=Ecl|Mood=Ind|Tense=Pres	15	acl:relcl	_	_
 17	foghlamtha	foghlamtha	ADJ	Adj	VerbForm=Part	16	xcomp:pred	_	_

--- a/ga_idt-ud-test.conllu
+++ b/ga_idt-ud-test.conllu
@@ -8932,7 +8932,7 @@
 35	chéile	céile	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	29	obl	_	_
 36	ar	ar	ADP	Cmpd	PrepForm=Cmpd	38	case	_	_
 37	son	son	NOUN	Cmpd	Case=Nom|Number=Sing|PrepForm=Cmpd	36	fixed	_	_
-38	tógáil	tógáil	NOUN	Noun	Case=Nom|Gender=Fem|Number=Sing	29	obl	_	_
+38	tógáil	tógáil	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	29	obl	_	_
 39	na	an	DET	Art	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	41	det	_	_
 40	'	'	PUNCT	Punct	_	41	punct	_	SpaceAfter=No
 41	Tíreolaíochta	tíreolaíocht	NOUN	Noun	Case=Gen|Definite=Def|Gender=Fem|Number=Sing	38	nmod	_	SpaceAfter=No
@@ -8940,7 +8940,7 @@
 43	mar	mar	ADP	Simp	_	44	case	_	_
 44	dhisciplín	disciplín	NOUN	Noun	Case=Nom|Form=Len|Gender=Masc|Number=Sing	38	nmod	_	_
 45	(	(	PUNCT	Punct	_	46	punct	_	SpaceAfter=No
-46	Céim	céim	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	44	nmod	_	_
+46	Céim	céim	NOUN	Noun	Case=Nom|Definite=Def|Gender=Fem|Number=Sing	33	appos	_	_
 47	II	II	NUM	Num	NumType=Card	46	nmod	_	_
 48	thíos	thíos	ADV	Dir	_	46	advmod	_	SpaceAfter=No
 49	)	)	PUNCT	Punct	_	46	punct	_	_
@@ -10176,7 +10176,7 @@
 3	chosnaíonn	cosain	VERB	VTI	Form=Len|Mood=Ind|Tense=Pres	0	root	_	_
 4	Beckett	Beckett	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	3	nsubj	_	SpaceAfter=No
 5	,	,	PUNCT	Punct	_	6	punct	_	_
-6	Joyce	Joyce	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	4	conj	_	_
+6	Joyce	Joyce	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	3	obj	_	_
 7	ar	ar	ADP	Simp	_	9	case	_	_
 8	na	an	DET	Art	Definite=Def|Number=Plur|PronType=Art	9	det	_	_
 9	gearáin	gearán	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Plur	3	obl	_	_
@@ -10940,7 +10940,7 @@
 93	shealbhú	sealbhú	NOUN	Noun	Form=Len|VerbForm=Inf	5	xcomp	_	_
 94	agus	agus	CCONJ	Coord	_	96	cc	_	_
 95	a	a	PART	Inf	PartType=Inf	96	mark	_	_
-96	bhainisteoireacht	bainisteoireacht	NOUN	Noun	Case=Nom|Form=Len|Gender=Fem|Number=Sing	93	conj	_	SpaceAfter=No
+96	bhainisteoireacht	bainisteoireacht	NOUN	Noun	Form=Len|VerbForm=Inf	93	conj	_	SpaceAfter=No
 97	;	;	PUNCT	Punct	_	104	punct	_	_
 98	-	-	PUNCT	Punct	_	104	punct	_	_
 99	gach	gach	DET	Det	Definite=Def	100	det	_	_
@@ -10994,8 +10994,8 @@
 20	chomh	chomh	ADV	Its	_	21	advmod	_	_
 21	contúirteach	contúirteach	ADJ	Adj	Degree=Pos	1	xcomp:pred	_	_
 22	le	le	ADP	Simp	_	23	case	_	_
-23	Coire	coire	NOUN	Noun	Case=Nom|Gender=Masc|Number=Sing	21	obl	_	NamedEntity=Yes
-24	Bhreacháin	Breachán	PROPN	Noun	Case=Gen|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
+23	Coire	coire	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	21	obl	_	NamedEntity=Yes
+24	Bhreacháin	Breachán	PROPN	Noun	Case=Gen|Definite=Def|Form=Len|Gender=Masc|Number=Sing	23	nmod	_	NamedEntity=Yes
 25	atá	bí	VERB	VI	Form=Direct|Mood=Ind|PronType=Rel|Tense=Pres	23	acl:relcl	_	_
 26	idir	idir	ADP	Simp	_	27	case	_	_
 27	Sgarba	Sgarba	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	25	xcomp:pred	_	_
@@ -11007,7 +11007,7 @@
 33	a	a	PART	Vb	Form=Indirect|PartType=Vb|PronType=Rel	34	mark:prt	_	_
 34	raibh	bí	VERB	VI	Mood=Ind|Tense=Past	32	acl:relcl	_	_
 35	an	an	DET	Art	Definite=Def|Number=Sing|PronType=Art	36	det	_	_
-36	sgríobhnóir	sgríobhnóir	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	34	nsubj	_	_
+36	sgríobhnóir	scríbhneoir	NOUN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	34	nsubj	_	_
 37	George	George	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	36	appos	_	NamedEntity=Yes
 38	Orwell	Orwell	PROPN	Noun	Case=Nom|Definite=Def|Gender=Masc|Number=Sing	37	flat:name	_	NamedEntity=Yes
 39	fá	faoi	ADP	Simp	Dialect=Ulster	40	case	_	_


### PR DESCRIPTION
The validator was reporting 167 warnings regarding use of flat:foreign.  This patch resolves all of those. It also includes various other fixes that I made along the way, but hopefully nothing controversial — sorry to mix it all up together.

In terms of the flat:foreign stuff, the three options for handling "foreign" material are laid out here:

https://universaldependencies.org/foreign.html

I followed "Option 2" in most cases which seems to make the most sense, and is closest to the way things were annotated already.

Option 3 was more appropriate in a small number of cases where the English text was something like a full quoted phrase vs. a proper name that played a syntactic role in the otherwise Irish sentence.  See for example the quoted phrase "that general Jail-Deliverer" in sent_id=85, or "Kill me, I Love You!" in sent_id=201.

